### PR TITLE
7 add administration backend services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # os2openclient
 Linux configuration management, OS deployment and monitoring.
 
+## Quick start guide
+- Make sure your demo enviroment has docker and compose installed
+- Clone this repo to your demo enviroment
+- Open a terminal, cd into the root of the cloned repo
+- Run docker compose up
+- The semaphore UI is availble on port 3000 in a browser
+
 ## Architecture proposal
 
 ### Cornerstone backend components:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Linux configuration management, OS deployment and monitoring.
 
 ## Quick start guide
 - Make sure your demo enviroment has docker and compose installed
+- Open SSH on port 22 on the device you want to manage and add it to same network as the demo enviroment.
 - Clone this repo to your demo enviroment
 - Open a terminal, cd into the root of the cloned repo
 - Run docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2'
+
+services:
+
+  mysql:
+    ports:
+      - 3306:3306
+    image: mysql:5.6
+    container_name: mysql
+    hostname: mysql
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+      MYSQL_DATABASE: semaphore_db
+      MYSQL_USER: semaphore_user
+      MYSQL_PASSWORD: StrongPassw0rd
+
+  semaphore:
+    ports:
+      - 3000:3000
+    image: ansiblesemaphore/semaphore:latest
+    container_name: semaphore
+    environment:
+      SEMAPHORE_DB_USER: semaphore_user
+      SEMAPHORE_DB_PASS: StrongPassw0rd
+      SEMAPHORE_DB_HOST: mysql
+      SEMAPHORE_DB_PORT: 3306
+      SEMAPHORE_DB: semaphore_db
+      SEMAPHORE_PLAYBOOK_PATH: /tmp/semaphore/
+      SEMAPHORE_ADMIN_PASSWORD: AdminPassword
+      SEMAPHORE_ADMIN_NAME: admin
+      SEMAPHORE_ADMIN_EMAIL: admin@computingforgeeks.com
+      SEMAPHORE_ADMIN: admin
+      SEMAPHORE_ACCESS_KEY_ENCRYPTION: MflCLIUF5bn6Lgkuwy4BoAdIFhoZ4Ief2oocXmuZSjs=
+    depends_on:
+      - mysql


### PR DESCRIPTION
A simple image based docker stack added with docker compose, with the purpose of evaluating ansible as administration tool.

How to test: 

1. Ansible + semaphore container boots and the web ui is reachable from admin machine.
2. It is possible to run a ansible playbook / command via SSH on a network connected device (Rpi)